### PR TITLE
fix: Fix getting performance metrics on host

### DIFF
--- a/mfd_esxi/host_api.py
+++ b/mfd_esxi/host_api.py
@@ -323,7 +323,15 @@ class ESXiHostAPI(object):
         :param create_chart: indicates if table with metrics should be created
         :return: table with gathered performance metrics
         """
-        esxi_host = self.get_host()
+        for _ in range(5):
+            try:
+                esxi_host = self.get_host()
+                break
+            except Exception:
+                logger.log(level=log_levels.MODULE_DEBUG, msg="Failed to get ESXi Host, retrying in 1 second...")
+                sleep(1)
+        else:
+            raise ESXiAPISocketError(f"Unable to connect to host {self._ip} after 5 attempts.")
         perf_manager = self._content.perfManager
 
         # Get all possible counters

--- a/tests/unit/test_mfd_esxi/test_host_api.py
+++ b/tests/unit/test_mfd_esxi/test_host_api.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: MIT
+import time
+from mfd_esxi.exceptions import ESXiAPISocketError
 
 
 class TestESXiHostApi:
@@ -35,3 +37,58 @@ class TestESXiHostApi:
                 "req_vfs": 8,
             }
         }
+
+    def test_returns_performance_metrics_table_for_multiple_adapters(self, mocker, host_api_with_cert):
+        mock_adapter1 = mocker.Mock()
+        mock_adapter1.name = "eth0"
+        mock_adapter2 = mocker.Mock()
+        mock_adapter2.name = "eth1"
+        mock_host = mocker.Mock()
+        mock_perf_manager = mocker.Mock()
+        mock_counter_info = {
+            "cpu.usage.average": 1,
+            "net.received.average": 2,
+            "net.transmitted.average": 3,
+        }
+        mock_stats = [
+            (["stat0"], "CPU"),
+            (["stat1"], "eth0-Rx"),
+            (["stat2"], "eth0-Tx"),
+            (["stat3"], "eth1-Rx"),
+            (["stat4"], "eth1-Tx"),
+        ]
+        mocker.patch.object(host_api_with_cert, "get_host", return_value=mock_host)
+        host_api_with_cert._ESXiHostAPI__content.perfManager = mock_perf_manager
+        mocker.patch.object(host_api_with_cert, "get_performance_metrics_keys", return_value=mock_counter_info)
+        mocker.patch.object(host_api_with_cert, "get_performance_metrics_stats", return_value=mock_stats)
+        mocker.patch.object(host_api_with_cert, "create_performance_metrics_table", return_value="table")
+        result = host_api_with_cert.get_performance_metrics([mock_adapter1, mock_adapter2])
+        assert result == "table"
+
+    def test_raises_error_after_five_failed_connection_attempts(self, host_api_with_cert, mocker):
+        mocker.patch.object(host_api_with_cert, "get_host", side_effect=Exception("fail"))
+        mocker.patch("mfd_esxi.host_api.sleep", mocker.create_autospec(time.sleep))
+        try:
+            host_api_with_cert.get_performance_metrics([])
+            assert False, "Should have raised ESXiAPISocketError"
+        except ESXiAPISocketError as e:
+            assert "Unable to connect to host" in str(e)
+
+    def test_returns_metrics_table_when_create_chart_false(self, host_api_with_cert, mocker):
+        mock_adapter = mocker.Mock()
+        mock_adapter.name = "eth0"
+        mock_host = mocker.Mock()
+        mock_perf_manager = mocker.Mock()
+        mock_counter_info = {
+            "cpu.usage.average": 1,
+            "net.received.average": 2,
+            "net.transmitted.average": 3,
+        }
+        mock_stats = [(["stat0"], "CPU"), (["stat1"], "eth0-Rx"), (["stat2"], "eth0-Tx")]
+        mocker.patch.object(host_api_with_cert, "get_host", return_value=mock_host)
+        host_api_with_cert._ESXiHostAPI__content.perfManager = mock_perf_manager
+        mocker.patch.object(host_api_with_cert, "get_performance_metrics_keys", return_value=mock_counter_info)
+        mocker.patch.object(host_api_with_cert, "get_performance_metrics_stats", return_value=mock_stats)
+        mocker.patch.object(host_api_with_cert, "create_performance_metrics_table", return_value={"some": "dict"})
+        result = host_api_with_cert.get_performance_metrics([mock_adapter], create_chart=False)
+        assert result == {"some": "dict"}


### PR DESCRIPTION
Getting ESXi host using VCSA API fails occasionally with no specific reason (with random manner). Try to get it several times before raising an exception.

Fixes #2 