### PR TITLE
ci: Update repository name handling in workflows for pull requests

### DIFF
--- a/.github/workflows/build_upload_whl.yml
+++ b/.github/workflows/build_upload_whl.yml
@@ -76,6 +76,7 @@ jobs:
           fetch-depth: 0
           path: ${{ inputs.SOURCE_PATH }}
           ref: ${{ inputs.BRANCH_NAME }}
+          repository: ${{ inputs.REPOSITORY_NAME }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -177,7 +178,7 @@ jobs:
           password: ${{ secrets.PYPI_TOKEN }}
 
       - name: Publish comment how to build .whl
-        if: inputs.RELEASE_BUILD == false
+        if: inputs.RELEASE_BUILD == false && (github.event.pull_request != null && github.event.pull_request.head.repo.full_name == github.repository) # skip for forks
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -19,7 +19,7 @@ jobs:
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
-      REPOSITORY_NAME: ${{ github.repository }}
+      REPOSITORY_NAME: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       BRANCH_NAME: ${{ github.head_ref }}
       PYTHON_VERSION: ${{ matrix.python_version }}
       PUSH_TAG: ${{ matrix.push_tag }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve handling of pull requests from forks and to ensure the correct repository is referenced throughout the build and upload process. The changes primarily focus on better support for external contributions and more robust workflow conditions.

**Workflow improvements for forked pull requests:**

* In `.github/workflows/pull_requests.yml`, the `REPOSITORY_NAME` input is now set to use the pull request's source repository (`github.event.pull_request.head.repo.full_name`) if available, falling back to the main repository otherwise. This ensures actions run against the correct repository for both internal and forked PRs.
* In `.github/workflows/build_upload_whl.yml`, the `repository` parameter is added to the checkout step, allowing the workflow to explicitly clone the correct repository, which is especially important for forked PRs.

**Conditional workflow execution:**

* The step that publishes a comment about building the `.whl` file now includes an additional condition to only run for PRs from the same repository, skipping forks to avoid unnecessary or potentially confusing comments.