### PR TITLE
feat: Retry sending request when problem with connection is raised

### DIFF
--- a/mfd_esxi/nsx/utils.py
+++ b/mfd_esxi/nsx/utils.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: MIT
 """NSX utilities."""
 import logging
+import urllib3
 
 from mfd_common_libs import add_logging_level, log_levels
 from typing import Callable, Any
+from time import sleep
 
 from mfd_esxi.exceptions import NsxApiCallError
 from com.vmware.vapi.std.errors_client import Error, Unauthorized, NotFound
@@ -34,6 +36,21 @@ def api_call(call: Callable) -> Callable:
                     msg=f"Calling {call.__name__} from {call.__module__} failed with:\n {e.to_json()}",
                 )
                 raise NsxApiCallError()
+        except (ConnectionError, urllib3.exceptions.ProtocolError):
+            sleep_between_tries = 2
+            num_of_retries = 2
+            for i in range(1, num_of_retries + 1):
+                try:
+                    logger.log(
+                        level=log_levels.MODULE_DEBUG,
+                        msg=f"Connection error detected, waiting {sleep_between_tries} seconds and "
+                            f"trying again ({i}/{num_of_retries}).",
+                    )
+                    sleep(sleep_between_tries)
+                    return call(*args, **kwargs)
+                except (ConnectionError, urllib3.exceptions.ProtocolError):
+                    continue
+            raise NsxApiCallError()
         except NotFound:
             raise
         except Error as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ packaging
 mfd_connect >= 7.12.0
 mfd_common_libs>=1.11.0
 mfd_network_adapter >= 14.0.0
+
+urllib3~=2.4.0


### PR DESCRIPTION
fixes #11 
Sometimes sending request to NSX-T raises an Exception meaning that there is a problem with connection to NSX-T. The next test usually has no problem with sending the same request. Retry sending such request twice if problem is encountered before raising an exception.
@Signed-off-by: Szymon Zmijewski <szymon.zmijewski@intel.com>