### PR TITLE
feat: Add configuration sync method and tests for IP addition

### DIFF
--- a/mfd_esxi/vmknic.py
+++ b/mfd_esxi/vmknic.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: MIT
 """Support for vmkernel adapters."""
 
@@ -141,6 +141,10 @@ class Vmknic:
         command = f"esxcli network vswitch standard portgroup set -p {self.portgroup} -v {vlan}"
         self.owner.execute_command(command)
 
+    def _sync_config(self) -> None:
+        """Sync configuration to persist changes across reboots."""
+        self.owner.execute_command("vim-cmd hostsvc/firmware/sync_config")
+
     def add_ip(self, ip: Union["IPv4Interface", "IPv6Interface", str]) -> None:
         """
         Set IPv4 or add IPv6.
@@ -162,6 +166,7 @@ class Vmknic:
                     self.ips.remove(i)
                     break
         self.ips.append(ip)
+        self._sync_config()
 
     def del_ip(self, ip: Union["IPv4Interface", "IPv6Interface", str]) -> None:
         """

--- a/tests/unit/test_mfd_esxi/test_vmknic.py
+++ b/tests/unit/test_mfd_esxi/test_vmknic.py
@@ -76,3 +76,14 @@ class TestVmknic:
     def test_discover_vxlan_vmk(self, host_esxcfg_vmknic_3):
         vmknics = Vmknic.discover(host_esxcfg_vmknic_3)
         assert len(vmknics) == 2
+
+    def test_sync_config(self, host):
+        vmknic = Vmknic(host, "vmk2")
+        vmknic._sync_config()
+        host.connection.execute_command.assert_called_with("vim-cmd hostsvc/firmware/sync_config")
+
+    def test_add_ip_calls_sync_config(self, host, mocker):
+        vmknic = Vmknic(host, "vmk2")
+        sync_mock = mocker.patch.object(vmknic, "_sync_config")
+        vmknic.add_ip("1.1.1.1/8")
+        sync_mock.assert_called_once()


### PR DESCRIPTION
This pull request adds functionality to ensure that configuration changes to VMkernel adapters are persisted across reboots by syncing the configuration after modifying IP addresses. It introduces a new method to handle the sync operation and updates the unit tests to verify this behavior.

Persistence and configuration syncing:

* Added a private method `_sync_config` to the `Vmknic` class in `vmknic.py`, which executes the `vim-cmd hostsvc/firmware/sync_config` command to persist configuration changes.
* Updated the `add_ip` method to call `_sync_config` after modifying the list of IPs, ensuring changes are saved across reboots.

Testing improvements:

* Added unit tests in `test_vmknic.py` to verify that `_sync_config` is called both directly and as part of the `add_ip` method, ensuring the persistence mechanism is tested.

Other:

* Updated the copyright year in `vmknic.py`.