### PR TITLE
chore: align CI and bump test dependencies

### DIFF
--- a/.github/dependency_review.yml
+++ b/.github/dependency_review.yml
@@ -1,4 +1,4 @@
-Ffail-on-severity: 'low'
+fail-on-severity: 'low'
 allow-licenses:
   - 'BSD-2-Clause'
   - 'BSD-3-Clause'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 -r requirements-test.txt
 
-mfd-code-quality >= 1.2.0, < 2
+mfd-code-quality >= 1.4.1, < 2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,8 @@
 -r requirements.txt
 
-pytest ~= 8.4
+pytest >= 9.0.3, < 10
 pytest-mock ~= 3.14
+setuptools >= 80.4.0, <= 81
 
 vsphere-automation-sdk @ git+https://github.com/vmware/vsphere-automation-sdk-python@v8.0.3.0
 


### PR DESCRIPTION
## Summary
- bump pytest and mfd-code-quality requirements
- pin setuptools below 81 so VMware SDK tests can still import `pkg_resources`
- align dependency review config with the shared workflow wrapper setup

## Validation
- `git diff --check`
- `pytest -q` (205 passed)
- `PyYAML` unavailable in the validation environment, so YAML parsing was skipped
