### PR TITLE
fix: Add NSX 9.1 compatibility for NsxHostTransportNode

### DIFF
--- a/mfd_esxi/nsx/host_transport_node.py
+++ b/mfd_esxi/nsx/host_transport_node.py
@@ -14,6 +14,7 @@ from mfd_esxi.exceptions import (
 
 from com.vmware.nsx_policy.model_client import (
     HostTransportNode,
+    FabricHostNode,
     StandardHostSwitchSpec,
     VdsUplink,
     StandardHostSwitch,
@@ -70,33 +71,32 @@ class NsxHostTransportNode(NsxEntity):
 
         raise NsxResourceSetupError(f"Timeout during operation on Host Transport Node {self.name}")
 
-    @api_call
-    def add(  # noqa: C901
-        self,
-        timeout: int = 600,
-    ) -> None:
+    def _require_discovered_node(self) -> FabricHostNode:
         """
-        Add host transport node to NSX. Only hosts that are present in VCSA with VDS-es are supported.
+        Look up the host in NSX fabric discovery and return the discovered node content.
 
-        :param timeout: Maximum time add node can take to resolve.
+        :raises NsxResourceSetupError: if the host is not present in fabric discovery.
+        """
+        discovered_node = NsxFabricDiscoveredNode(self.name, self._connection).content
+        if discovered_node is None:
+            raise NsxResourceSetupError(f"Host transport node '{self.name}' not found in fabric discovery")
+        return discovered_node
+
+    @api_call
+    def add(self) -> None:
+        """
+        Validate that the host is visible in NSX fabric discovery.
+
+        Verifies the host is already registered as a transport node, or that it is present in
+        fabric discovery so that add_switch() can create the transport node with its first
+        HostSwitch in a single PATCH call (required for NSX 9.1+ compatibility).
+
+        Raises NsxResourceSetupError if the host is absent from fabric discovery.
         """
         if self.content is not None:
             return
 
-        discovered_node = NsxFabricDiscoveredNode(self.name, self._connection).content
-        if discovered_node is None:
-            # Standalone ESXi hosts are not supported. They need to be present in discovery
-            raise NsxResourceSetupError("Transport node missing in discovery")
-
-        switch_specs = StandardHostSwitchSpec(host_switches=[])
-        payload = HostTransportNode(
-            discovered_node_id_for_create=discovered_node.external_id,
-            display_name=self.name,
-            host_switch_spec=switch_specs,
-            description=f"Transport Node {self.name}",
-        )
-
-        self._patch(payload=payload, timeout=timeout)
+        self._require_discovered_node()
 
     @api_call
     def add_switch(  # noqa: C901
@@ -128,7 +128,15 @@ class NsxHostTransportNode(NsxEntity):
         """
         payload: HostTransportNode = self.content
         if payload is None:
-            raise MissingNsxEntity(f"Host Transport Node {self.name} is missing")
+            # NSX 9.1+ requires at least one HostSwitch at transport node creation time.
+            # add() skips bare node creation; the node is created here with the first
+            # switch already configured in a single PATCH call.
+            discovered_node = self._require_discovered_node()
+            payload = HostTransportNode(
+                discovered_node_id_for_create=discovered_node.external_id,
+                display_name=self.name,
+                description=f"Transport Node {self.name}",
+            )
 
         uplink_list = []
         for i in range(1, uplinks + 1):
@@ -190,12 +198,15 @@ class NsxHostTransportNode(NsxEntity):
         self._patch(payload=payload, timeout=timeout)
 
     @api_call
-    def delete_switches_return_uplink_profiles(self, timeout: int = 600) -> List[str]:
+    def get_uplink_profile_names(self) -> List[str]:
         """
-        Delete all host switches.
+        Return the uplink profile names referenced by all host switches on this transport node.
 
-        :param timeout: maximum time to resolve request
-        :return: list of their uplink profiles
+        :return: list of uplink profile names (empty list if the node has no content or no switches)
+
+        Note: this method is read-only. NSX 9.1+ rejects PATCH with an empty host_switches list
+        (error 9643), so switch removal is no longer performed here. Call delete() to fully
+        remove the transport node.
         """
         payload: HostTransportNode = self.content
         if payload is None or payload.host_switch_spec is None:
@@ -206,10 +217,6 @@ class NsxHostTransportNode(NsxEntity):
             for up in switch.host_switch_profile_ids:
                 if up.key == HostSwitchProfileTypeIdEntry.KEY_UPLINKHOSTSWITCHPROFILE:
                     names.append(up.value.split("/")[-1])
-
-        payload.host_switch_spec = StandardHostSwitchSpec(host_switches=[])
-
-        self._patch(payload=payload, timeout=timeout)
 
         return names
 

--- a/tests/unit/test_mfd_esxi/test_nsx/test_host_transport_node.py
+++ b/tests/unit/test_mfd_esxi/test_nsx/test_host_transport_node.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 import pytest
 
-from mfd_esxi.exceptions import MissingNsxEntity
+from mfd_esxi.exceptions import NsxResourceSetupError
 from mfd_esxi.nsx.connection import NsxConnection
 from mfd_esxi.nsx.host_transport_node import NsxHostTransportNode
 
@@ -22,9 +22,58 @@ class TestHostTransportNode:
         yield host_tn
         mocker.stopall()
 
+    def test_require_discovered_node_raises_when_absent(self, host_transport_node, mocker):
+        mock_fdn = mocker.patch(
+            "mfd_esxi.nsx.host_transport_node.NsxFabricDiscoveredNode",
+        )
+        mock_fdn.return_value.content = None
+
+        with pytest.raises(NsxResourceSetupError, match="test_transport_node"):
+            host_transport_node._require_discovered_node()
+
+    def test_require_discovered_node_returns_node(self, host_transport_node, mocker):
+        mock_node = mocker.Mock(external_id="ext-999")
+        mock_fdn = mocker.patch(
+            "mfd_esxi.nsx.host_transport_node.NsxFabricDiscoveredNode",
+        )
+        mock_fdn.return_value.content = mock_node
+
+        result = host_transport_node._require_discovered_node()
+
+        assert result is mock_node
+
+    def test_add_already_exists_returns_early(self, host_transport_node, mocker):
+        host_transport_node._get_content = mocker.Mock(return_value=mocker.Mock())
+
+        host_transport_node.add()
+
+        host_transport_node._patch.assert_not_called()
+
+    def test_add_no_discovery_raises(self, host_transport_node, mocker):
+        host_transport_node._get_content = mocker.Mock(return_value=None)
+        host_transport_node._require_discovered_node = mocker.Mock(
+            side_effect=NsxResourceSetupError("not found"),
+        )
+
+        with pytest.raises(NsxResourceSetupError):
+            host_transport_node.add()
+
+    def test_add_host_visible_no_patch(self, host_transport_node, mocker):
+        host_transport_node._get_content = mocker.Mock(return_value=None)
+        host_transport_node._require_discovered_node = mocker.Mock(
+            return_value=mocker.Mock(external_id="ext-123"),
+        )
+
+        host_transport_node.add()
+
+        host_transport_node._patch.assert_not_called()
+
     def test_add_switch_with_uplink_param(self, host_transport_node, mocker):
         vds_id = "test"
-        mock_standard_host_switch = mocker.patch("mfd_esxi.nsx.host_transport_node.StandardHostSwitch", autospec=True)
+        mock_standard_host_switch = mocker.patch(
+            "mfd_esxi.nsx.host_transport_node.StandardHostSwitch",
+            autospec=True,
+        )
         host_transport_node.add_switch(
             host_switch_name="test_sw",
             uplink_name="uplink",
@@ -40,7 +89,10 @@ class TestHostTransportNode:
 
     def test_add_switch_without_uplink_param(self, host_transport_node, mocker):
         # test whether Exception is not raised when uplink param is not provided
-        mock_standard_host_switch = mocker.patch("mfd_esxi.nsx.host_transport_node.StandardHostSwitch", autospec=True)
+        mock_standard_host_switch = mocker.patch(
+            "mfd_esxi.nsx.host_transport_node.StandardHostSwitch",
+            autospec=True,
+        )
         host_transport_node.add_switch(
             host_switch_name="test_sw",
             uplink_name="uplink",
@@ -54,9 +106,13 @@ class TestHostTransportNode:
 
         assert len(kwargs["uplinks"]) == ESXI_UPLINK_NUMBER
 
-    def test_add_switch_no_payload(self, host_transport_node, mocker):
+    def test_add_switch_no_payload_no_discovery_raises(self, host_transport_node, mocker):
         host_transport_node._get_content = mocker.Mock(return_value=None)
-        with pytest.raises(MissingNsxEntity):
+        host_transport_node._require_discovered_node = mocker.Mock(
+            side_effect=NsxResourceSetupError("not found"),
+        )
+
+        with pytest.raises(NsxResourceSetupError):
             host_transport_node.add_switch(
                 host_switch_name="test_sw",
                 uplink_name="uplink",
@@ -64,3 +120,63 @@ class TestHostTransportNode:
                 vds_id="test",
                 ip_pool_id=None,
             )
+
+    def test_add_switch_no_payload_creates_node_inline(self, host_transport_node, mocker):
+        host_transport_node._get_content = mocker.Mock(return_value=None)
+        host_transport_node._require_discovered_node = mocker.Mock(
+            return_value=mocker.Mock(external_id="ext-456"),
+        )
+        mocker.patch(
+            "mfd_esxi.nsx.host_transport_node.StandardHostSwitch",
+            autospec=True,
+        )
+
+        host_transport_node.add_switch(
+            host_switch_name="test_sw",
+            uplink_name="uplink",
+            transport_zone_name="test_tz",
+            vds_id="test",
+            ip_pool_id=None,
+        )
+
+        host_transport_node._patch.assert_called_once()
+
+    def test_get_uplink_profile_names_no_payload_returns_empty(self, host_transport_node, mocker):
+        host_transport_node._get_content = mocker.Mock(return_value=None)
+
+        result = host_transport_node.get_uplink_profile_names()
+
+        assert result == []
+        host_transport_node._patch.assert_not_called()
+
+    def test_get_uplink_profile_names_no_host_switch_spec_returns_empty(self, host_transport_node, mocker):
+        mock_payload = mocker.Mock()
+        mock_payload.host_switch_spec = None
+        host_transport_node._get_content = mocker.Mock(return_value=mock_payload)
+
+        result = host_transport_node.get_uplink_profile_names()
+
+        assert result == []
+        host_transport_node._patch.assert_not_called()
+
+    def test_get_uplink_profile_names_returns_names_without_patch(self, host_transport_node, mocker):
+        from mfd_esxi.nsx.host_transport_node import HostSwitchProfileTypeIdEntry
+
+        uplink_entry = mocker.Mock()
+        uplink_entry.key = HostSwitchProfileTypeIdEntry.KEY_UPLINKHOSTSWITCHPROFILE
+        uplink_entry.value = "/infra/host-switch-profiles/my-uplink-profile"
+
+        mock_switch = mocker.Mock()
+        mock_switch.host_switch_profile_ids = [uplink_entry]
+
+        mock_spec = mocker.Mock()
+        mock_spec.host_switches = [mock_switch]
+
+        mock_payload = mocker.Mock()
+        mock_payload.host_switch_spec.convert_to.return_value = mock_spec
+        host_transport_node._get_content = mocker.Mock(return_value=mock_payload)
+
+        result = host_transport_node.get_uplink_profile_names()
+
+        assert result == ["my-uplink-profile"]
+        host_transport_node._patch.assert_not_called()


### PR DESCRIPTION
Enhance the MFD to support ESX9.1. Made NsxHostTransportNode compatible with NSX 9.1